### PR TITLE
Add GET /healthz

### DIFF
--- a/src/controllers/ping.controller.ts
+++ b/src/controllers/ping.controller.ts
@@ -1,10 +1,10 @@
 import {inject} from '@loopback/core';
 import {
   Request,
+  ResponseObject,
   RestBindings,
   get,
   response,
-  ResponseObject,
 } from '@loopback/rest';
 
 /**
@@ -38,12 +38,25 @@ const PING_RESPONSE: ResponseObject = {
  * A simple controller to bounce back http requests
  */
 export class PingController {
-  constructor(@inject(RestBindings.Http.REQUEST) private req: Request) {}
+  constructor(@inject(RestBindings.Http.REQUEST) private req: Request) { }
 
   // Map to `GET /ping`
   @get('/ping')
   @response(200, PING_RESPONSE)
   ping(): object {
+    // Reply with a greeting, the current time, the url, and request headers
+    return {
+      greeting: 'Hello from LoopBack',
+      date: new Date(),
+      url: this.req.url,
+      headers: Object.assign({}, this.req.headers),
+    };
+  }
+
+  // Map to `GET /healthz`
+  @get('/healthz')
+  @response(200, PING_RESPONSE)
+  healthz(): object {
     // Reply with a greeting, the current time, the url, and request headers
     return {
       greeting: 'Hello from LoopBack',


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by openai -->
### Summary by OpenAI

Release Notes:
- New Feature: Added a new endpoint `GET /healthz` to the `PingController` class, which returns a JSON object containing a greeting, current time, URL, and request headers.

> "A new endpoint has arrived,
> 'GET /healthz' is now alive.
> With greetings, time, and headers too,
> This feature brings joy to me and you."
<!-- end of auto-generated comment: release notes by openai -->